### PR TITLE
chore(deps): upgrade bliss-svg-builder to 1.0.0-rc.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@preact/signals": "^2.9.0",
         "@types/node": "^25.9.3",
-        "bliss-svg-builder": "^1.0.0-rc.2",
+        "bliss-svg-builder": "^1.0.0-rc.4",
         "htm": "^3.1.1",
         "ollama": "^0.6.3",
         "preact": "^10.23.2",
@@ -2337,9 +2337,9 @@
       }
     },
     "node_modules/bliss-svg-builder": {
-      "version": "1.0.0-rc.3",
-      "resolved": "https://registry.npmjs.org/bliss-svg-builder/-/bliss-svg-builder-1.0.0-rc.3.tgz",
-      "integrity": "sha512-tBvOGCTfp+SykxLgoP9nTarq9Zj5XpNF3NmY0r7vwQH8D3qwFJFAM6nDmTf/ph69qsM07lJbobvDuEei1qgmvg==",
+      "version": "1.0.0-rc.4",
+      "resolved": "https://registry.npmjs.org/bliss-svg-builder/-/bliss-svg-builder-1.0.0-rc.4.tgz",
+      "integrity": "sha512-H7BhHSso/KZxmeZMaQY83HlDBAtSFGC4e6X0Gi1A7/xBDvDuFqQ0suUbdvMogyWXh1UHG07deXszFMho62QGFA==",
       "license": "MPL-2.0",
       "engines": {
         "node": ">=18"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "@preact/signals": "^2.9.0",
     "@types/node": "^25.9.3",
-    "bliss-svg-builder": "^1.0.0-rc.2",
+    "bliss-svg-builder": "^1.0.0-rc.4",
     "htm": "^3.1.1",
     "ollama": "^0.6.3",
     "preact": "^10.23.2",


### PR DESCRIPTION
## Description

This PR targets `chore/remove-rag-support` (#135) directly, so its diff is limited to the single commit that bumps `bliss-svg-builder` from the `^1.0.0-rc.2` range (which resolved rc.3) to `1.0.0-rc.4`: `package.json` + `package-lock.json`.

rc.4 needs no application code changes, verified against this branch's rendering path:

- All 6420 dataset symbols and all 1549 semicolon-bearing compositions render under rc.4 with zero warnings. Every composition resolves to single-glyph heads via `getResolvedComposition`, so rc.4's strict `;` vs `;;` indicator separation places each indicator correctly at the character level.
- The app calls only `new BlissSVGBuilder(bstr)` plus `svgCode` and `svgElement`, so rc.4's breaking changes to `applyIndicators`, `toString`, and `toJSON` do not apply.
- The only visible rendering change is the intended smaller SDOT indicator dots (per the bliss-svg-builder changelog).

## Verification

- `npm run typecheck`: passes.
- `npm run test`: 306 tests across 90 files pass.
- `npm run lint`: `lint:js` has no real findings; on a Windows checkout it shows only `linebreak-style` CRLF noise from `core.autocrlf`, which does not occur on CI.

## Steps to test

1. Confirm this PR's diff is limited to `package.json` and `package-lock.json`.
2. Run `npm run typecheck` and `npm run test`.
3. Confirm both files reference `bliss-svg-builder` at `1.0.0-rc.4`.

## Note

This replaces #152, which targeted `inclusive-design:main`. Re-sent against `chore/remove-rag-support` (#135) per review request, so it can be reviewed and merged as a stacked change.
